### PR TITLE
Fix link to repository

### DIFF
--- a/_docs/competition-parser.md
+++ b/_docs/competition-parser.md
@@ -11,4 +11,4 @@ A parser to convert pdf to results for Lifesaving Rankings
 
 Author: Ruben van Erk
 
-Link: <https://github.com/rubenvanerk/lifesavingrankings>
+Link: <https://github.com/rubenvanerk/competition-parser-lumen>


### PR DESCRIPTION
First of all: great initiative. Absolutely love this collection of Lifesaving projects.

This pull request fixes the link to the (new) competition parser.